### PR TITLE
Fix broken link in footer

### DIFF
--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -250,7 +250,7 @@ export const ListData = {
                     },
                     {
                         name: 'API Documentation',
-                        link: 'https://dscgocdnapi.azureedge.net/docs'
+                        link: 'https://goadmin.ifrc.org/docs'
                     },
                     {
                         name: 'Other Resources',


### PR DESCRIPTION
Set URL to match the footer on main GO platform site. 

#32 mentions fixing the broken footer links, and perhaps that was true at the time, however the issue was never closed. Unsure when the link broke again.